### PR TITLE
Brand the storefront for Pisces Shirts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Pisces Shirts E-commerce
+
+This repository contains a Medusa backend and a Next.js storefront configured to sell shirts online. The project is split into two folders:
+
+- **backend** – Medusa server containing products and checkout logic.
+- **backend-storefront** – Next.js 15 storefront for customers.
+
+## Local Setup
+
+1. Ensure Node.js 20 and PostgreSQL are installed.
+2. Copy `backend/.env.template` to `backend/.env` and fill in the database connection.
+3. Install dependencies (requires internet access):
+   ```bash
+   cd backend && npm install
+   cd ../backend-storefront && npm install
+   ```
+4. Seed demo data:
+   ```bash
+   cd ../backend
+   npm run seed
+   ```
+5. Run both apps:
+   ```bash
+   npm run dev  # in backend
+   npm run dev  # in backend-storefront
+   ```
+
+## Deployment
+
+Deploy the backend and storefront separately. The frontend expects the backend to run on `http://localhost:9000` by default. Update environment variables as needed for production.
+
+## Testing
+
+Run Medusa's integration tests from the backend folder:
+```bash
+npm run test:integration:http
+```
+Tests require installed dependencies and may not run in restricted environments.

--- a/backend-storefront/README.md
+++ b/backend-storefront/README.md
@@ -9,11 +9,11 @@
 </p>
 
 <h1 align="center">
-  Medusa Next.js Starter Template
+  Pisces Shirts Storefront
 </h1>
 
 <p align="center">
-Combine Medusa's modules for your commerce backend with the newest Next.js 15 features for a performant storefront.</p>
+A production-ready storefront powered by Medusa and Next.js for selling high-quality shirts.</p>
 
 <p align="center">
   <a href="https://github.com/medusajs/medusa/blob/master/CONTRIBUTING.md">

--- a/backend-storefront/src/modules/home/components/hero/index.tsx
+++ b/backend-storefront/src/modules/home/components/hero/index.tsx
@@ -10,24 +10,15 @@ const Hero = () => {
             level="h1"
             className="text-3xl leading-10 text-ui-fg-base font-normal"
           >
-            Ecommerce Starter Template
+            Pisces Shirts
           </Heading>
           <Heading
             level="h2"
             className="text-3xl leading-10 text-ui-fg-subtle font-normal"
           >
-            Powered by Medusa and Next.js
+            High-quality shirts for all seasons
           </Heading>
         </span>
-        <a
-          href="https://github.com/medusajs/nextjs-starter-medusa"
-          target="_blank"
-        >
-          <Button variant="secondary">
-            View on GitHub
-            <Github />
-          </Button>
-        </a>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add a root README with setup instructions
- rebrand storefront hero to "Pisces Shirts"
- update storefront README heading

## Testing
- `npm run test:integration:http` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684314dd4f84832f9cb585091a8161b4