### PR TITLE
Expand Traders Connect prototype

### DIFF
--- a/traders-connect/.gitignore
+++ b/traders-connect/.gitignore
@@ -1,0 +1,13 @@
+**/node_modules/
+*.log
+.env
+!.env.example
+web/.env.local
+!web/.env.local.example
+server/data.sqlite
+web/.next/
+
+package-lock.json
+
+# Mac
+.DS_Store

--- a/traders-connect/README.md
+++ b/traders-connect/README.md
@@ -1,0 +1,15 @@
+# Traders Connect
+
+Traders Connect is a community platform for prop firm and retail traders. The project
+includes a Next.js web frontend, an Express API backend powered by SQLite, and a basic
+SwiftUI iOS application skeleton. This sample demonstrates the core architecture with
+authentication, profile loading and firm management.
+
+## Getting Started
+
+1. `cd server && npm install` to install API dependencies
+2. `cp server/.env.example server/.env` and set a secure `JWT_SECRET`
+3. `npm start` inside `server` to run the API
+4. In another terminal `cd web && npm install`
+5. `cp web/.env.local.example web/.env.local` and adjust `NEXT_PUBLIC_API_URL`
+6. `npm run dev` inside `web` to start the frontend

--- a/traders-connect/ios/README.md
+++ b/traders-connect/ios/README.md
@@ -1,0 +1,5 @@
+# Traders Connect iOS
+
+A minimal SwiftUI application structure to connect to the Traders Connect API.
+This skeleton provides a starting point for building the iOS client with real
+time chat and push notifications using Firebase in the future.

--- a/traders-connect/ios/TradersConnect/ContentView.swift
+++ b/traders-connect/ios/TradersConnect/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        NavigationView {
+            Text("Traders Connect")
+                .navigationTitle("Home")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/traders-connect/ios/TradersConnect/TradersConnectApp.swift
+++ b/traders-connect/ios/TradersConnect/TradersConnectApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TradersConnectApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/traders-connect/server/.env.example
+++ b/traders-connect/server/.env.example
@@ -1,0 +1,1 @@
+JWT_SECRET=changeme

--- a/traders-connect/server/README.md
+++ b/traders-connect/server/README.md
@@ -1,0 +1,12 @@
+# Traders Connect API
+
+This Express server provides authentication and basic firm management for the
+Traders Connect platform. It uses a local SQLite database managed with
+`better-sqlite3` and JWT based authentication.
+
+## Available Scripts
+
+- `npm run dev` – start the server with watch mode
+- `npm start` – start the API server
+
+Create a `.env` file based on `.env.example` and set `JWT_SECRET`.

--- a/traders-connect/server/package.json
+++ b/traders-connect/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "traders-connect-server",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/index.js",
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "better-sqlite3": "^11.10.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/traders-connect/server/src/db.js
+++ b/traders-connect/server/src/db.js
@@ -1,0 +1,22 @@
+import Database from 'better-sqlite3';
+
+const db = new Database('data.sqlite');
+
+db.exec(`
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE,
+  password TEXT,
+  name TEXT
+);
+CREATE TABLE IF NOT EXISTS firms (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT,
+  email TEXT,
+  website TEXT,
+  rules TEXT,
+  approved INTEGER DEFAULT 0
+);
+`);
+
+export default db;

--- a/traders-connect/server/src/index.js
+++ b/traders-connect/server/src/index.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import cors from 'cors';
+import authRoutes from './routes/auth.js';
+import userRoutes from './routes/users.js';
+import firmRoutes from './routes/firms.js';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (_req, res) => {
+  res.json({ message: 'Traders Connect API' });
+});
+
+app.use('/api/auth', authRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/firms', firmRoutes);
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/traders-connect/server/src/routes/auth.js
+++ b/traders-connect/server/src/routes/auth.js
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import db from '../db.js';
+
+const router = Router();
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+router.post('/register', async (req, res) => {
+  const { email, password, name } = req.body;
+  if (!email || !password)
+    return res.status(400).json({ error: 'Missing fields' });
+
+  const existing = db
+    .prepare('SELECT id FROM users WHERE email = ?')
+    .get(email);
+  if (existing) return res.status(400).json({ error: 'Email taken' });
+
+  const hashed = await bcrypt.hash(password, 10);
+  const stmt = db.prepare(
+    'INSERT INTO users (email, password, name) VALUES (?, ?, ?)'
+  );
+  const info = stmt.run(email, hashed, name || '');
+  res.json({ id: info.lastInsertRowid });
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = db.prepare('SELECT * FROM users WHERE email = ?').get(email);
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = jwt.sign({ userId: user.id }, SECRET, { expiresIn: '1h' });
+  res.json({ token, user: { id: user.id, email: user.email, name: user.name } });
+});
+
+export default router;

--- a/traders-connect/server/src/routes/firms.js
+++ b/traders-connect/server/src/routes/firms.js
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import db from '../db.js';
+import jwt from 'jsonwebtoken';
+
+const router = Router();
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+function authMiddleware(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header) return res.status(401).json({ error: 'Missing token' });
+  const token = header.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, SECRET);
+    req.userId = payload.userId;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+router.post('/', authMiddleware, (req, res) => {
+  const { name, email, website, rules } = req.body;
+  if (!name) return res.status(400).json({ error: 'Missing fields' });
+  const stmt = db.prepare(
+    'INSERT INTO firms (name, email, website, rules) VALUES (?, ?, ?, ?)'
+  );
+  const info = stmt.run(name, email || '', website || '', rules || '');
+  res.json({ id: info.lastInsertRowid });
+});
+
+router.get('/', (_req, res) => {
+  const rows = db.prepare('SELECT id, name, website, approved FROM firms WHERE approved = 1').all();
+  res.json(rows);
+});
+
+export default router;

--- a/traders-connect/server/src/routes/users.js
+++ b/traders-connect/server/src/routes/users.js
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import db from '../db.js';
+import jwt from 'jsonwebtoken';
+
+const router = Router();
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+function authMiddleware(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header) return res.status(401).json({ error: 'Missing token' });
+  const token = header.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, SECRET);
+    req.userId = payload.userId;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+router.get('/me', authMiddleware, (req, res) => {
+  const user = db.prepare('SELECT id, email, name FROM users WHERE id = ?').get(req.userId);
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  res.json(user);
+});
+
+export default router;

--- a/traders-connect/web/.env.local.example
+++ b/traders-connect/web/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/traders-connect/web/README.md
+++ b/traders-connect/web/README.md
@@ -1,0 +1,5 @@
+# Traders Connect Web
+
+This is a minimal Next.js + TailwindCSS frontend. It connects to the Traders
+Connect API for authentication and real-time features. Run `npm install` and
+`npm run dev` to start the development server.

--- a/traders-connect/web/context/AuthContext.tsx
+++ b/traders-connect/web/context/AuthContext.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { api } from '../lib/api';
+
+interface User {
+  id: number;
+  email: string;
+  name: string;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, name: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token');
+    if (stored) {
+      api('/users/me', { headers: { Authorization: `Bearer ${stored}` } })
+        .then(setUser)
+        .catch(() => localStorage.removeItem('token'));
+    }
+  }, []);
+
+  async function login(email: string, password: string) {
+    const data = await api('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password })
+    });
+    localStorage.setItem('token', data.token);
+    setUser(data.user);
+  }
+
+  async function register(email: string, password: string, name: string) {
+    await api('/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({ email, password, name })
+    });
+    await login(email, password);
+  }
+
+  function logout() {
+    localStorage.removeItem('token');
+    setUser(null);
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('AuthContext');
+  return ctx;
+}

--- a/traders-connect/web/lib/api.ts
+++ b/traders-connect/web/lib/api.ts
@@ -1,0 +1,13 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+export async function api(path: string, options: RequestInit = {}) {
+  const res = await fetch(`${API_URL}/api${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {})
+    }
+  });
+  if (!res.ok) throw new Error('API error');
+  return res.json();
+}

--- a/traders-connect/web/next-env.d.ts
+++ b/traders-connect/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/traders-connect/web/next.config.js
+++ b/traders-connect/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/traders-connect/web/package.json
+++ b/traders-connect/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "traders-connect-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "autoprefixer": "^10.4.15",
+    "next": "14.1.0",
+    "postcss": "^8.4.31",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "24.0.1",
+    "@types/react": "19.1.8",
+    "typescript": "5.8.3"
+  }
+}

--- a/traders-connect/web/pages/_app.tsx
+++ b/traders-connect/web/pages/_app.tsx
@@ -1,0 +1,11 @@
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+import { AuthProvider } from '../context/AuthContext';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
+}

--- a/traders-connect/web/pages/dashboard.tsx
+++ b/traders-connect/web/pages/dashboard.tsx
@@ -1,0 +1,23 @@
+import { useAuth } from '../context/AuthContext';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function Dashboard() {
+  const { user, logout } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user) router.push('/login');
+  }, [user, router]);
+
+  if (!user) return null;
+
+  return (
+    <main className="p-6">
+      <h1 className="text-3xl font-bold">Welcome, {user.name || user.email}</h1>
+      <button onClick={logout} className="mt-4 bg-primary px-3 py-1 rounded">
+        Logout
+      </button>
+    </main>
+  );
+}

--- a/traders-connect/web/pages/index.tsx
+++ b/traders-connect/web/pages/index.tsx
@@ -1,0 +1,16 @@
+export default function Home() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center text-center">
+      <h1 className="text-4xl font-bold text-primary">Traders Connect</h1>
+      <p className="mt-4">Community platform coming soon.</p>
+      <div className="space-x-4 mt-6">
+        <a href="/login" className="underline">
+          Login
+        </a>
+        <a href="/register" className="underline">
+          Register
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/traders-connect/web/pages/login.tsx
+++ b/traders-connect/web/pages/login.tsx
@@ -1,0 +1,47 @@
+import { FormEvent, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      router.push('/dashboard');
+    } catch (err) {
+      setError('Login failed');
+    }
+  }
+
+  return (
+    <main className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 p-6 bg-gray-800 rounded">
+        <h1 className="text-2xl font-bold">Login</h1>
+        {error && <p className="text-red-500">{error}</p>}
+        <input
+          className="block w-64 p-2 rounded bg-gray-900"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          className="block w-64 p-2 rounded bg-gray-900"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="bg-primary px-4 py-2 rounded" type="submit">
+          Login
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/traders-connect/web/pages/register.tsx
+++ b/traders-connect/web/pages/register.tsx
@@ -1,0 +1,54 @@
+import { FormEvent, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useRouter } from 'next/router';
+
+export default function Register() {
+  const { register } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await register(email, password, name);
+      router.push('/dashboard');
+    } catch (err) {
+      setError('Registration failed');
+    }
+  }
+
+  return (
+    <main className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 p-6 bg-gray-800 rounded">
+        <h1 className="text-2xl font-bold">Register</h1>
+        {error && <p className="text-red-500">{error}</p>}
+        <input
+          className="block w-64 p-2 rounded bg-gray-900"
+          placeholder="Name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          className="block w-64 p-2 rounded bg-gray-900"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          className="block w-64 p-2 rounded bg-gray-900"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="bg-primary px-4 py-2 rounded" type="submit">
+          Register
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/traders-connect/web/postcss.config.js
+++ b/traders-connect/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/traders-connect/web/styles/globals.css
+++ b/traders-connect/web/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-black text-white;
+}

--- a/traders-connect/web/tailwind.config.js
+++ b/traders-connect/web/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#F0B90B',
+          dark: '#C89E0A'
+        }
+      }
+    },
+  },
+  plugins: [],
+};

--- a/traders-connect/web/tsconfig.json
+++ b/traders-connect/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- implement SQLite-backed Express API and new firm routes
- add authentication and user profile context in Next.js app
- create login, register, and dashboard pages
- document setup steps and configuration samples

## Testing
- `npm run build` in `traders-connect/web`
- `npm start` in `traders-connect/server`


------
https://chatgpt.com/codex/tasks/task_e_684a3f2a318c832f8af08e963c70ff35